### PR TITLE
:wrench: Implement searchAfter for participants (phenotypes)

### DIFF
--- a/admin/conf.json
+++ b/admin/conf.json
@@ -1,5 +1,5 @@
 {
-    "migration_test_qa": {
+    "next_qa": {
         "indices": [
             {
                 "graphqlField": "members",
@@ -7,11 +7,11 @@
             },
             {
                 "graphqlField": "studies",
-                "esIndex": "migration_test_study_centric"
+                "esIndex": "next_study_centric"
             },
             {
                 "graphqlField": "participant",
-                "esIndex": "migration_test_participant_centric"
+                "esIndex": "next_participant_centric"
             },
             {
                 "graphqlField": "variants",
@@ -23,11 +23,11 @@
             },
             {
                 "graphqlField": "biospecimens",
-                "esIndex": "migration_test_biospecimen_centric"
+                "esIndex": "next_biospecimen_centric"
             },
             {
                 "graphqlField": "files",
-                "esIndex": "migration_test_file_centric"
+                "esIndex": "next_file_centric"
             }
         ],
         "extendedMappingMutations": [
@@ -251,6 +251,63 @@
             {
                 "field": "interests",
                 "graphqlField": "members",
+                "extendedFieldMappingInput": {
+                    "isArray": true
+                }
+            },
+
+            {
+                "field": "participants.study.search_text",
+                "graphqlField": "files",
+                "extendedFieldMappingInput": {
+                    "isArray": true
+                }
+            },
+            {
+                "field": "study.search_text",
+                "graphqlField": "files",
+                "extendedFieldMappingInput": {
+                    "isArray": true
+                }
+            },
+            {
+                "field": "study.search_text",
+                "graphqlField": "participant",
+                "extendedFieldMappingInput": {
+                    "isArray": true
+                }
+            },
+            {
+                "field": "search_text",
+                "graphqlField": "studies",
+                "extendedFieldMappingInput": {
+                    "isArray": true
+                }
+            },
+            {
+                "field": "participant.study.search_text",
+                "graphqlField": "biospecimens",
+                "extendedFieldMappingInput": {
+                    "isArray": true
+                }
+            },
+            {
+                "field": "study.search_text",
+                "graphqlField": "biospecimens",
+                "extendedFieldMappingInput": {
+                    "isArray": true
+                }
+            },
+            {
+                "field": "participants.study",
+                "graphqlField": "files",
+                "extendedFieldMappingInput": {
+                    "type": "object"
+                }
+            },
+            {
+                "field": "sequencing_experiment",
+                "graphqlField": "files",
                 "extendedFieldMappingInput": {
                     "isArray": true
                 }

--- a/admin/run.mjs
+++ b/admin/run.mjs
@@ -34,10 +34,10 @@ console.info(`admin-project-script - Starting script`);
 //values are hardcoded for now, but as soon as possible, we should use env var from env.ts
 const projectIndices =
     [
-        'migration_test_participant_centric',
-        'migration_test_study_centric',
-        'migration_test_biospecimen_centric',
-        'migration_test_file_centric',
+        'next_participant_centric',
+        'next_study_centric',
+        'next_biospecimen_centric',
+        'next_file_centric',
         'variant_centric',
         'gene_centric',
         'members-public',

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -20,7 +20,7 @@ import { getStatistics, Statistics } from './endpoints/statistics';
 import { calculateSurvivalForSqonResult } from './endpoints/survival';
 import { keycloakClient, keycloakRealm, keycloakURL } from './env';
 import { RiffError } from './riff/riffError';
-import { ArrangerProject } from './sqon/searchSqon';
+import { ArrangerProject} from "./arrangerUtils";
 
 jest.mock('./endpoints/sets/setsFeature');
 jest.mock('./endpoints/survival');

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,7 +25,7 @@ import { globalErrorHandler, globalErrorLogger } from './errors';
 import { STATISTICS_CACHE_ID, verifyCache } from './middleware/cache';
 import { injectBodyHttpHeaders } from './middleware/injectBodyHttpHeaders';
 import { resolveSetIdMiddleware } from './middleware/resolveSetIdInSqon';
-import { ArrangerProject } from './sqon/searchSqon';
+import { ArrangerProject } from './arrangerUtils';
 import { getPhenotypesNodes } from './endpoints/phenotypes';
 
 export default (keycloak: Keycloak, sqs: SQS, getProject: (projectId: string) => ArrangerProject): Express => {

--- a/src/arrangerUtils.ts
+++ b/src/arrangerUtils.ts
@@ -1,0 +1,8 @@
+import { ExecutionResult } from 'graphql/execution/execute';
+
+type RunQuery = ({ query, variables }: { query: unknown; variables: unknown }) => Promise<ExecutionResult>;
+
+export type ArrangerProject = {
+    runQuery: ({ query: string, variables: unknown }) => Promise<ExecutionResult>;
+};
+export const runProjectQuery = (project: ArrangerProject): RunQuery => project.runQuery;

--- a/src/endpoints/searchByIds/executePagedQuery.ts
+++ b/src/endpoints/searchByIds/executePagedQuery.ts
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 
-import { ArrangerProject } from '../../sqon/searchSqon';
+import { ArrangerProject } from '../../arrangerUtils';
 import { SetSqon } from '../sets/setsTypes';
 import { normalizeResults } from './normalizeResults';
 

--- a/src/endpoints/searchByIds/searchAllSources.ts
+++ b/src/endpoints/searchByIds/searchAllSources.ts
@@ -1,6 +1,6 @@
 import { flatten } from 'lodash';
 
-import { ArrangerProject } from '../../sqon/searchSqon';
+import { ArrangerProject } from '../../arrangerUtils';
 import { byBiospecimenId } from './byBiospecimenId';
 import { byFamilyId } from './byFamilyId';
 import { byId } from './byId';

--- a/src/endpoints/sets/setsFeature.test.ts
+++ b/src/endpoints/sets/setsFeature.test.ts
@@ -10,7 +10,8 @@ import {
     RIFF_TYPE_SET,
 } from '../../riff/riffClient';
 import { resolveSetsInSqon } from '../../sqon/resolveSetInSqon';
-import { ArrangerProject, searchSqon } from '../../sqon/searchSqon';
+import { searchSqon } from '../../sqon/searchSqon';
+import { ArrangerProject } from '../../arrangerUtils';
 import { sendSetInSQSQueue } from '../../SQS/sendEvent';
 import { createSet, deleteSet, getSets, SubActionTypes, updateSetContent, updateSetTag } from './setsFeature';
 import { CreateSetBody, Set, Sort, UpdateSetContentBody, UpdateSetTagBody } from './setsTypes';
@@ -60,7 +61,7 @@ describe('Set management', () => {
     const setFromRiff: Set = {
         id: setId,
         tag,
-        size: mockParticipantIds.length
+        size: mockParticipantIds.length,
     };
 
     describe('Get user sets using Riff API', () => {

--- a/src/endpoints/sets/setsFeature.ts
+++ b/src/endpoints/sets/setsFeature.ts
@@ -13,7 +13,8 @@ import {
 } from '../../riff/riffClient';
 import { addSqonToSetSqon, removeSqonToSetSqon } from '../../sqon/manipulateSqon';
 import { resolveSetsInSqon } from '../../sqon/resolveSetInSqon';
-import { ArrangerProject, searchSqon } from '../../sqon/searchSqon';
+import { searchSqon } from '../../sqon/searchSqon';
+import { ArrangerProject } from '../../arrangerUtils';
 import {
     EventCreate,
     EventCreateValue,

--- a/src/endpoints/survival.ts
+++ b/src/endpoints/survival.ts
@@ -1,9 +1,9 @@
 import { get, min } from 'lodash';
 import { Options, PythonShell } from 'python-shell';
 
+import { ArrangerProject } from '../arrangerUtils';
 import { idKey, pythonPath, survivalPyFile } from '../env';
 import { resolveSetsInSqon } from '../sqon/resolveSetInSqon';
-import { ArrangerProject } from '../sqon/searchSqon';
 import { SetSqon } from './sets/setsTypes';
 
 const pyOptions: Options = { pythonPath, mode: 'text', pythonOptions: ['-u'] };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
+import { ExecutionResult } from 'graphql/execution/execute';
 import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 
 import { SetNotFoundError } from './endpoints/sets/setError';
@@ -20,4 +21,10 @@ export const globalErrorHandler = (err: unknown, _req: Request, res: Response, _
 export const globalErrorLogger = (err: unknown, _req: Request, _res: Response, next: NextFunction): void => {
     console.error(err);
     next(err);
+};
+
+export const throwErrorsFromGqlQueryIfExist = (resp: ExecutionResult): void | never => {
+    if (resp.errors) {
+        throw new Error(resp.errors.join(','));
+    }
 };

--- a/src/sqon/searchSqon.ts
+++ b/src/sqon/searchSqon.ts
@@ -1,12 +1,10 @@
 import { graphql } from 'graphql';
 import { get } from 'lodash';
 
+import { ArrangerProject } from '../arrangerUtils';
 import { SetSqon, Sort } from '../endpoints/sets/setsTypes';
 import { maxSetContentSize } from '../env';
 
-export type ArrangerProject = {
-    runQuery: ({ query: string, variables: unknown }) => Promise<unknown>;
-};
 export const searchSqon = async (
     sqon: SetSqon,
     projectId: string,
@@ -49,7 +47,7 @@ export const searchSqon = async (
     return ids;
 };
 
-export const runQuery = ({ query, variables, mock, project }) => {
+const runQuery = ({ query, variables, mock, project }) => {
     const schema = mock ? project.mockSchema : project.schema;
     return graphql({
         schema,

--- a/src/sqon/searchSqon.ts
+++ b/src/sqon/searchSqon.ts
@@ -2,7 +2,7 @@ import { graphql } from 'graphql';
 import { get } from 'lodash';
 
 import { SetSqon, Sort } from '../endpoints/sets/setsTypes';
-import { idKey, maxSetContentSize } from '../env';
+import { maxSetContentSize } from '../env';
 
 export type ArrangerProject = {
     runQuery: ({ query: string, variables: unknown }) => Promise<unknown>;
@@ -49,7 +49,7 @@ export const searchSqon = async (
     return ids;
 };
 
-const runQuery = ({ query, variables, mock, project }) => {
+export const runQuery = ({ query, variables, mock, project }) => {
     const schema = mock ? project.mockSchema : project.schema;
     return graphql({
         schema,


### PR DESCRIPTION
At this moment, if we have a query, in the portal, with more than 10k participants we may miss some phenotypes. The fix consists in using the searchAfter api in the method that fetches the participants.

It seems to work, but maybe we should use this mechanism in other functions too such as this [one](https://github.com/kids-first/kf-api-arranger/blob/3615b9b0b6c9bd389e4126c5ac5076a14fdfe552/src/endpoints/phenotypes.ts#L33). For now, I prefer to refactor as little as possible.

NOTE: this code won`t be in Include. We are on branch 2.0 used by kf-portal-next.